### PR TITLE
fix StaticFS

### DIFF
--- a/fileserver.go
+++ b/fileserver.go
@@ -244,7 +244,7 @@ func (engine *Engine) StaticFS(relativePath string, fs http.FileSystem) {
 		relativePath += "/"
 	}
 
-	fileServer := http.FileServer(fs)
+	fileServer := http.StripPrefix(relativePath, http.FileServer(fs))
 	engine.ANY(relativePath+"*filepath", GetStaticFSHandleFunc(fileServer))
 }
 
@@ -258,7 +258,7 @@ func (group *RouterGroup) StaticFS(relativePath string, fs http.FileSystem) {
 		relativePath += "/"
 	}
 
-	fileServer := http.FileServer(fs)
+	fileServer := http.StripPrefix(relativePath, http.FileServer(fs))
 	group.ANY(relativePath+"*filepath", GetStaticFSHandleFunc(fileServer))
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 修复在带路径前缀的路由下提供静态资源时的解析问题，避免出现错误的 404 与资源定位偏移。
  - 改善子路径部署场景（如 /assets、/static）的访问一致性，确保文件从预期根目录正确解析。
  - 与现有公开接口保持兼容，无需代码迁移或配置变更。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->