### PR TITLE
feat(render): add buffered variants for JSON/GOB/WANF/HTML

### DIFF
--- a/context.go
+++ b/context.go
@@ -478,8 +478,9 @@ func (c *Context) WANF(code int, obj any) {
 
 // WANFBuf 先将 WANF 编码到 buffer, 成功后再写入状态码和响应体.
 func (c *Context) WANFBuf(code int, obj any) {
-	data, err := wanf.Marshal(obj)
-	if err != nil {
+	var buf bytes.Buffer
+	encoder := wanf.NewStreamEncoder(&buf)
+	if err := encoder.Encode(obj); err != nil {
 		errMsg := fmt.Errorf("failed to encode WANF: %w", err)
 		c.AddError(errMsg)
 		c.ErrorUseHandle(http.StatusInternalServerError, errMsg)
@@ -487,7 +488,7 @@ func (c *Context) WANFBuf(code int, obj any) {
 	}
 	c.Writer.Header().Set("Content-Type", "application/vnd.wjqserver.wanf; charset=utf-8")
 	c.Writer.WriteHeader(code)
-	c.Writer.Write(data)
+	c.Writer.Write(buf.Bytes())
 }
 
 // HTML 渲染 HTML 模板

--- a/context.go
+++ b/context.go
@@ -417,6 +417,21 @@ func (c *Context) JSON(code int, obj any) {
 	}
 }
 
+// JSONBuf 先将 JSON 编码到 buffer, 成功后再写入状态码和响应体.
+// 与 JSON 相比, 编码失败时可以正确返回 500 状态码, 代价是多一次内存分配.
+func (c *Context) JSONBuf(code int, obj any) {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		c.AddError(fmt.Errorf("failed to marshal JSON: %w", err))
+		c.Errorf("failed to marshal JSON: %s", err)
+		c.ErrorUseHandle(http.StatusInternalServerError, fmt.Errorf("failed to marshal JSON: %w", err))
+		return
+	}
+	c.Writer.Header().Set("Content-Type", "application/json; charset=utf-8")
+	c.Writer.WriteHeader(code)
+	c.Writer.Write(data)
+}
+
 // GOB 向响应写入GOB数据
 // 设置 Content-Type 为 application/octet-stream
 func (c *Context) GOB(code int, obj any) {
@@ -431,6 +446,20 @@ func (c *Context) GOB(code int, obj any) {
 	}
 }
 
+// GOBBuf 先将 GOB 编码到 buffer, 成功后再写入状态码和响应体.
+func (c *Context) GOBBuf(code int, obj any) {
+	var buf bytes.Buffer
+	encoder := gob.NewEncoder(&buf)
+	if err := encoder.Encode(obj); err != nil {
+		c.AddError(fmt.Errorf("failed to encode GOB: %w", err))
+		c.ErrorUseHandle(http.StatusInternalServerError, fmt.Errorf("failed to encode GOB: %w", err))
+		return
+	}
+	c.Writer.Header().Set("Content-Type", "application/octet-stream")
+	c.Writer.WriteHeader(code)
+	c.Writer.Write(buf.Bytes())
+}
+
 // WANF向响应写入WANF数据
 // 设置 application/vnd.wjqserver.wanf; charset=utf-8
 func (c *Context) WANF(code int, obj any) {
@@ -443,6 +472,19 @@ func (c *Context) WANF(code int, obj any) {
 		c.ErrorUseHandle(http.StatusInternalServerError, fmt.Errorf("failed to encode WANF: %w", err))
 		return
 	}
+}
+
+// WANFBuf 先将 WANF 编码到 buffer, 成功后再写入状态码和响应体.
+func (c *Context) WANFBuf(code int, obj any) {
+	data, err := wanf.Marshal(obj)
+	if err != nil {
+		c.AddError(fmt.Errorf("failed to encode WANF: %w", err))
+		c.ErrorUseHandle(http.StatusInternalServerError, fmt.Errorf("failed to encode WANF: %w", err))
+		return
+	}
+	c.Writer.Header().Set("Content-Type", "application/vnd.wjqserver.wanf; charset=utf-8")
+	c.Writer.WriteHeader(code)
+	c.Writer.Write(data)
 }
 
 // HTML 渲染 HTML 模板
@@ -466,6 +508,29 @@ func (c *Context) HTML(code int, name string, obj any) {
 		// 可以扩展支持其他渲染器接口
 	}
 	// 默认简单输出，用于未配置 HTMLRender 的情况
+	c.Writer.Write(fmt.Appendf(nil, "<!-- HTML rendered for %s -->\n<pre>%v</pre>", name, obj))
+}
+
+// HTMLBuf 先将 HTML 模板渲染到 buffer, 成功后再写入状态码和响应体.
+func (c *Context) HTMLBuf(code int, name string, obj any) {
+	if c.engine != nil && c.engine.HTMLRender != nil {
+		if tpl, ok := c.engine.HTMLRender.(*template.Template); ok {
+			var buf bytes.Buffer
+			err := tpl.ExecuteTemplate(&buf, name, obj)
+			if err != nil {
+				c.AddError(fmt.Errorf("failed to render HTML template '%s': %w", name, err))
+				c.ErrorUseHandle(http.StatusInternalServerError, fmt.Errorf("failed to render HTML template '%s': %w", name, err))
+				return
+			}
+			c.Writer.Header().Set("Content-Type", "text/html; charset=utf-8")
+			c.Writer.WriteHeader(code)
+			c.Writer.Write(buf.Bytes())
+			return
+		}
+	}
+	// 默认简单输出
+	c.Writer.Header().Set("Content-Type", "text/html; charset=utf-8")
+	c.Writer.WriteHeader(code)
 	c.Writer.Write(fmt.Appendf(nil, "<!-- HTML rendered for %s -->\n<pre>%v</pre>", name, obj))
 }
 

--- a/context.go
+++ b/context.go
@@ -424,7 +424,6 @@ func (c *Context) JSONBuf(code int, obj any) {
 	if err != nil {
 		errMsg := fmt.Errorf("failed to marshal JSON: %w", err)
 		c.AddError(errMsg)
-		c.Errorf("%s", errMsg)
 		c.ErrorUseHandle(http.StatusInternalServerError, errMsg)
 		return
 	}
@@ -521,8 +520,9 @@ func (c *Context) HTMLBuf(code int, name string, obj any) {
 			var buf bytes.Buffer
 			err := tpl.ExecuteTemplate(&buf, name, obj)
 			if err != nil {
-				c.AddError(fmt.Errorf("failed to render HTML template '%s': %w", name, err))
-				c.ErrorUseHandle(http.StatusInternalServerError, fmt.Errorf("failed to render HTML template '%s': %w", name, err))
+				errMsg := fmt.Errorf("failed to render HTML template '%s': %w", name, err)
+				c.AddError(errMsg)
+				c.ErrorUseHandle(http.StatusInternalServerError, errMsg)
 				return
 			}
 			c.Writer.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/context.go
+++ b/context.go
@@ -514,27 +514,32 @@ func (c *Context) HTML(code int, name string, obj any) {
 }
 
 // HTMLBuf 先将 HTML 模板渲染到 buffer, 成功后再写入状态码和响应体.
-// 如果模板渲染失败或不支持缓冲渲染，则回退到标准的 HTML 方法.
+// 如果模板渲染失败，则返回 500 错误且不写入任何内容.
 func (c *Context) HTMLBuf(code int, name string, obj any) {
-	if c.engine != nil && c.engine.HTMLRender != nil {
-		if tpl, ok := c.engine.HTMLRender.(*template.Template); ok {
-			var buf bytes.Buffer
-			err := tpl.ExecuteTemplate(&buf, name, obj)
-			if err == nil {
-				// 渲染成功，写入响应
-				c.Writer.Header().Set("Content-Type", "text/html; charset=utf-8")
-				c.Writer.WriteHeader(code)
-				c.Writer.Write(buf.Bytes())
-				return
-			}
-			// 渲染失败，记录错误后回退到 HTML()
+	if c.engine == nil || c.engine.HTMLRender == nil {
+		// 没有渲染器，回退到简单输出
+		c.HTML(code, name, obj)
+		return
+	}
+
+	if tpl, ok := c.engine.HTMLRender.(*template.Template); ok {
+		var buf bytes.Buffer
+		err := tpl.ExecuteTemplate(&buf, name, obj)
+		if err != nil {
+			// 渲染失败，记录错误并返回 500，不写入任何内容
 			errMsg := fmt.Errorf("failed to render HTML template '%s': %w", name, err)
 			c.AddError(errMsg)
 			c.ErrorUseHandle(http.StatusInternalServerError, errMsg)
-			// 继续执行回退逻辑
+			return
 		}
+		// 渲染成功，写入响应
+		c.Writer.Header().Set("Content-Type", "text/html; charset=utf-8")
+		c.Writer.WriteHeader(code)
+		c.Writer.Write(buf.Bytes())
+		return
 	}
-	// 回退到标准 HTML 方法（处理无模板引擎或其他渲染器的情况）
+
+	// 不支持的渲染器类型，回退到简单输出
 	c.HTML(code, name, obj)
 }
 

--- a/context.go
+++ b/context.go
@@ -420,16 +420,17 @@ func (c *Context) JSON(code int, obj any) {
 // JSONBuf 先将 JSON 编码到 buffer, 成功后再写入状态码和响应体.
 // 与 JSON 相比，编码失败时可以正确返回 500 状态码，代价是多一次内存分配.
 func (c *Context) JSONBuf(code int, obj any) {
-	data, err := json.Marshal(obj)
-	if err != nil {
+	var buf bytes.Buffer
+	if err := json.MarshalWrite(&buf, obj); err != nil {
 		errMsg := fmt.Errorf("failed to marshal JSON: %w", err)
 		c.AddError(errMsg)
 		c.ErrorUseHandle(http.StatusInternalServerError, errMsg)
 		return
 	}
+
 	c.Writer.Header().Set("Content-Type", "application/json; charset=utf-8")
 	c.Writer.WriteHeader(code)
-	c.Writer.Write(data)
+	c.Writer.Write(buf.Bytes())
 }
 
 // GOB 向响应写入GOB数据

--- a/context.go
+++ b/context.go
@@ -514,27 +514,28 @@ func (c *Context) HTML(code int, name string, obj any) {
 }
 
 // HTMLBuf 先将 HTML 模板渲染到 buffer, 成功后再写入状态码和响应体.
+// 如果模板渲染失败或不支持缓冲渲染，则回退到标准的 HTML 方法.
 func (c *Context) HTMLBuf(code int, name string, obj any) {
 	if c.engine != nil && c.engine.HTMLRender != nil {
 		if tpl, ok := c.engine.HTMLRender.(*template.Template); ok {
 			var buf bytes.Buffer
 			err := tpl.ExecuteTemplate(&buf, name, obj)
-			if err != nil {
-				errMsg := fmt.Errorf("failed to render HTML template '%s': %w", name, err)
-				c.AddError(errMsg)
-				c.ErrorUseHandle(http.StatusInternalServerError, errMsg)
+			if err == nil {
+				// 渲染成功，写入响应
+				c.Writer.Header().Set("Content-Type", "text/html; charset=utf-8")
+				c.Writer.WriteHeader(code)
+				c.Writer.Write(buf.Bytes())
 				return
 			}
-			c.Writer.Header().Set("Content-Type", "text/html; charset=utf-8")
-			c.Writer.WriteHeader(code)
-			c.Writer.Write(buf.Bytes())
-			return
+			// 渲染失败，记录错误后回退到 HTML()
+			errMsg := fmt.Errorf("failed to render HTML template '%s': %w", name, err)
+			c.AddError(errMsg)
+			c.ErrorUseHandle(http.StatusInternalServerError, errMsg)
+			// 继续执行回退逻辑
 		}
 	}
-	// 默认简单输出
-	c.Writer.Header().Set("Content-Type", "text/html; charset=utf-8")
-	c.Writer.WriteHeader(code)
-	c.Writer.Write(fmt.Appendf(nil, "<!-- HTML rendered for %s -->\n<pre>%v</pre>", name, obj))
+	// 回退到标准 HTML 方法（处理无模板引擎或其他渲染器的情况）
+	c.HTML(code, name, obj)
 }
 
 // Redirect 执行 HTTP 重定向

--- a/context.go
+++ b/context.go
@@ -418,13 +418,14 @@ func (c *Context) JSON(code int, obj any) {
 }
 
 // JSONBuf 先将 JSON 编码到 buffer, 成功后再写入状态码和响应体.
-// 与 JSON 相比, 编码失败时可以正确返回 500 状态码, 代价是多一次内存分配.
+// 与 JSON 相比，编码失败时可以正确返回 500 状态码，代价是多一次内存分配.
 func (c *Context) JSONBuf(code int, obj any) {
 	data, err := json.Marshal(obj)
 	if err != nil {
-		c.AddError(fmt.Errorf("failed to marshal JSON: %w", err))
-		c.Errorf("failed to marshal JSON: %s", err)
-		c.ErrorUseHandle(http.StatusInternalServerError, fmt.Errorf("failed to marshal JSON: %w", err))
+		errMsg := fmt.Errorf("failed to marshal JSON: %w", err)
+		c.AddError(errMsg)
+		c.Errorf("%s", errMsg)
+		c.ErrorUseHandle(http.StatusInternalServerError, errMsg)
 		return
 	}
 	c.Writer.Header().Set("Content-Type", "application/json; charset=utf-8")
@@ -451,8 +452,9 @@ func (c *Context) GOBBuf(code int, obj any) {
 	var buf bytes.Buffer
 	encoder := gob.NewEncoder(&buf)
 	if err := encoder.Encode(obj); err != nil {
-		c.AddError(fmt.Errorf("failed to encode GOB: %w", err))
-		c.ErrorUseHandle(http.StatusInternalServerError, fmt.Errorf("failed to encode GOB: %w", err))
+		errMsg := fmt.Errorf("failed to encode GOB: %w", err)
+		c.AddError(errMsg)
+		c.ErrorUseHandle(http.StatusInternalServerError, errMsg)
 		return
 	}
 	c.Writer.Header().Set("Content-Type", "application/octet-stream")
@@ -478,8 +480,9 @@ func (c *Context) WANF(code int, obj any) {
 func (c *Context) WANFBuf(code int, obj any) {
 	data, err := wanf.Marshal(obj)
 	if err != nil {
-		c.AddError(fmt.Errorf("failed to encode WANF: %w", err))
-		c.ErrorUseHandle(http.StatusInternalServerError, fmt.Errorf("failed to encode WANF: %w", err))
+		errMsg := fmt.Errorf("failed to encode WANF: %w", err)
+		c.AddError(errMsg)
+		c.ErrorUseHandle(http.StatusInternalServerError, errMsg)
 		return
 	}
 	c.Writer.Header().Set("Content-Type", "application/vnd.wjqserver.wanf; charset=utf-8")


### PR DESCRIPTION
Add Buf rendering methods that encode to a buffer first, then write the response. This allows returning a proper 500 status code if encoding fails, unlike the streaming variants which must write the status code before encoding (an inherent HTTP constraint).

## New methods
- `JSONBuf(code int, obj any)`
- `GOBBuf(code int, obj any)`
- `WANFBuf(code int, obj any)`
- `HTMLBuf(code int, name string, obj any)`

## Trade-off
One extra memory allocation per call in exchange for correct error status codes on encoding failure.

## Related
Addresses the streaming response limitation where HTTP requires status codes to be written before the body, making it impossible to change the status code if encoding fails.