### PR TITLE
fix: avoid panic in case-insensitive wildcard lookup

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -852,7 +852,7 @@ walk: // 外部循环用于遍历路由树
 			return nil // 未找到, 返回 nil
 		}
 
-		n = n.children[0] // 移动到通配符子节点(通常是唯一一个)
+		n = n.children[len(n.children)-1] // 通配符子节点约定始终位于末尾
 		switch n.nType {
 		case param: // 参数节点
 			// 查找参数结束位置('/' 或路径末尾)

--- a/tree_test.go
+++ b/tree_test.go
@@ -901,6 +901,34 @@ func TestTreeInvalidNodeType(t *testing.T) {
 	}
 }
 
+func TestFindCaseInsensitivePathWithStaticAndParamRoutesDoesNotPanicOnMiss(t *testing.T) {
+	tree := &node{}
+	routes := [...]string{
+		"/:user/:repo/info/refs",
+		"/healthz",
+		"/api/db/data",
+		"/api/db/sum",
+	}
+
+	for _, route := range routes {
+		tree.addRoute(route, fakeHandler(route))
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("unexpected panic while looking up missing path: %v", r)
+		}
+	}()
+
+	if out, found := tree.findCaseInsensitivePath("/does-not-exist", true); found || out != nil {
+		t.Fatalf("expected missing path lookup to return no match, got %q, %t", string(out), found)
+	}
+
+	if out, found := tree.findCaseInsensitivePath("/does-not-exist", false); found || out != nil {
+		t.Fatalf("expected missing path lookup without trailing slash fix to return no match, got %q, %t", string(out), found)
+	}
+}
+
 func TestTreeInvalidParamsType(t *testing.T) {
 	tree := &node{}
 	// add a child with wildcard


### PR DESCRIPTION
## Summary
- align `findCaseInsensitivePathRec` with the router tree invariant that wildcard children are stored at the end of `children`
- add a regression test covering mixed static and param routes so a missing path lookup returns no match instead of panicking
- preserve normal 404 and redirect handling by preventing the internal fixed-path lookup from selecting a static child as a wildcard node

## Testing
- `go test ./...`